### PR TITLE
fix, refactor(i3): Assigns on ws5

### DIFF
--- a/config/i3/config
+++ b/config/i3/config
@@ -246,7 +246,6 @@ assign [class="Godot"] $ws4
 assign [class="Soffice"] $ws5
 assign [instance="libreoffice"] $ws5
 assign [class="discord"] $ws8
-assign [title="GitHub"] $ws9
 assign [class="floorp"] $ws9
 assign [class="Bitwarden"] $ws10
 assign [class="obsidian"] $ws10


### PR DESCRIPTION
- Cleans the assign section of i3conf
- Removes `Github` as an assign
- Catch any other instance of `libreoffice`